### PR TITLE
Popup preview sprint5

### DIFF
--- a/Client/src/components/GitHubUserInfo.js
+++ b/Client/src/components/GitHubUserInfo.js
@@ -97,7 +97,7 @@ function GitHubUserInfo(props) {
                     { data.blog !== "" ?
                     <span className="mx-2">
                         <img src={gh_blog_icon} alt="" className="mb-1" style={ICON_STYLES.github_main} />
-                        <a href={data.blog} target="_blank"> {data.blog} </a>
+                        <a href={data.blog} target="_blank" rel="noopener noreferrer"> {data.blog} </a>
                     </span>
                     : "" }
                 </Col>

--- a/Client/src/components/GitHubUserRepoInfo.js
+++ b/Client/src/components/GitHubUserRepoInfo.js
@@ -62,7 +62,7 @@ function GitHubUserRepoInfo(props) {
                                 <table>
                                   <tbody>
                                     <tr>
-                                        <td><a href={repo.html_url} target="_blank">{repo.name}</a></td>
+                                        <td><a href={repo.html_url} target="_blank" rel="noopener noreferrer" >{repo.name}</a></td>
                                     </tr>
                                     <tr>
                                         <td>{repo.description}</td>

--- a/Client/src/components/GitHubUserRepoInfo.js
+++ b/Client/src/components/GitHubUserRepoInfo.js
@@ -72,7 +72,6 @@ function GitHubUserRepoInfo(props) {
                                             { repo.language !== null ?
                                                 <Badge className="mr-2" pill variant="warning">{repo.language}</Badge>
                                             : "" }
-                                              {/* (previously above) <span className="mr-2">{repo.language}</span> */}
                                             <span className="mr-2">
                                                 <img src={gh_star} alt="" className="mb-1" style={ICON_STYLES.github_main} /> {repo.stargazers_count}
                                             </span>

--- a/Client/src/components/ViewProfile.js
+++ b/Client/src/components/ViewProfile.js
@@ -22,8 +22,8 @@ import { GrLinkedin } from 'react-icons/gr';
 import { GrStar } from 'react-icons/gr';
 
 const ICON_STYLES = {
-    height: "20px",
-    width: "20px",
+    height: "22px",
+    width: "22px",
     cursor: "pointer"
 }
 
@@ -201,28 +201,34 @@ function ProfileData(props) {
                 </Col>
                 <Col className="text-left font-italic pl-4" style={{color: '#343a40'}} xs={7} md={6}>
                     <h1 className="mb-0 pb-0 pl-1">{displayName}</h1>
-                    <span className="my-2 text-info">{email}</span><br />
-                    <span className="pl-4">
+                    <span className="my-2 text-info pl-3">{email}</span><br />
+                    <span className="pl-3">
+                        { linkedIn !== "" ? 
                         <a href={"https://www.linkedin.com/in/" + linkedIn}  target="_blank" rel="noopener noreferrer" style={ICON_STYLES_LINK}>
                             <GrLinkedin className="mr-3 my-2" style={ICON_STYLES}/>
                         </a>
+                        : "" }
+                        { twitter !== "" ?
                         <a href={"https://twitter.com/" + twitter}  target="_blank" rel="noopener noreferrer" style={ICON_STYLES_LINK}>
                             <GrTwitter className="mr-3 my-2" style={ICON_STYLES}/> 
                         </a>
+                        : "" }
+                        { gitHub !== "" ?
                         <a href={"https://github.com/" + gitHub}  target="_blank" rel="noopener noreferrer" style={ICON_STYLES_LINK}>
                             <GrGithub className="mr-3 my-2" style={ICON_STYLES}/>
-                        </a> <br />
-                        <div className="pl-3">
-                            <Button variant="primary" size="sm" variant="outline-dark" className="py-0 my-2" onClick={() => openPopupPreview()}>
+                        </a>
+                        : "" }
+                        { gitHub !== "" ?
+                            <Button variant="primary" size="sm" variant="outline-dark" className="py-0" onClick={() => openPopupPreview()}>
                                 GitHub Preview
                             </Button>
-                        </div>
+                        : "" }
                     </span>
                 </Col>
                 <Col xs={1} md={1}></Col>
             </Row>
             <div className="container-fluid col-8">
-            <div className="text-capitalize col-auto border rounded border-warning" style={{color: '#343a40'}}>
+            <div className="text-capitalize col-auto border rounded border-warning mt-2" style={{color: '#343a40'}}>
             <dl className="row auto-x mb-0">
                 <dt className="col-sm-12 col-md-4 col-lg-4 text-md-right">{awardCourse}COURSES</dt>
                 <dd className="col-sm-12 col-md-8 col-lg-8 font-italic">| {noCourses}{courses && courses.map(course => <span key={course}><a href={courseSearchURL[course]}>{course} </a> | </span>)}</dd>

--- a/Client/src/components/ViewProfile.js
+++ b/Client/src/components/ViewProfile.js
@@ -190,13 +190,13 @@ function ProfileData(props) {
                     <h1 className="mb-0 pb-0 pl-1">{displayName}</h1>
                     <span className="my-2 text-info">{email}</span><br />
                     <span className="pl-4">
-                        <a href={"https://www.linkedin.com/in/" + linkedIn}  target="_blank" style={ICON_STYLES_LINK}>
+                        <a href={"https://www.linkedin.com/in/" + linkedIn}  target="_blank" rel="noopener noreferrer" style={ICON_STYLES_LINK}>
                             <GrLinkedin className="mr-3 my-2" style={ICON_STYLES}/>
                         </a>
-                        <a href={"https://twitter.com/" + twitter}  target="_blank" style={ICON_STYLES_LINK}>
+                        <a href={"https://twitter.com/" + twitter}  target="_blank" rel="noopener noreferrer" style={ICON_STYLES_LINK}>
                             <GrTwitter className="mr-3 my-2" style={ICON_STYLES}/> 
                         </a>
-                        <a href={"https://github.com/" + gitHub}  target="_blank" style={ICON_STYLES_LINK}>
+                        <a href={"https://github.com/" + gitHub}  target="_blank" rel="noopener noreferrer" style={ICON_STYLES_LINK}>
                             <GrGithub className="mr-3 my-2" style={ICON_STYLES}/>
                         </a> <br />
                         <div className="pl-3">


### PR DESCRIPTION
-Fixed potential security issue associated with using target='_blank' in components that handle viewing an expert's profile and GitHub preview.

- Fixed bug where social media icons were showing up even when that expert had not provided their username/account for that social media website. Made minor adjustments to ViewProfile.js layout to account for this change.
